### PR TITLE
Fix: list, dm, routing

### DIFF
--- a/src/components/Popup/Letter/Letter.tsx
+++ b/src/components/Popup/Letter/Letter.tsx
@@ -112,7 +112,6 @@ function Letter(props: LetterProps): ReactElement {
     }
 
     if (isEmpty(formState.errors) && isWrite && typeof data === 'number') {
-      console.log(value.content);
       sendDM.mutate({ puzzleId: data, message: value });
     }
   };
@@ -208,7 +207,10 @@ function Letter(props: LetterProps): ReactElement {
           </MessageCard>
           {isWrite && (
             <ButtonSection css={buttonSectionCss}>
-              <Button buttonType={ButtonType.Text} onClick={onSubmit}>
+              <Button
+                buttonType={sendDM.isLoading ? ButtonType.Disabled : ButtonType.Text}
+                onClick={onSubmit}
+                disabled={sendDM.isLoading}>
                 DM 보내기
               </Button>
             </ButtonSection>

--- a/src/components/notFound/NotFound.tsx
+++ b/src/components/notFound/NotFound.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import route from 'src/core/const/route.path';
 import Button, { ButtonType } from '../button/Button';
 import KakaoAdFit from '../kakaoAd/kakaoAdFit';
-import { useSession } from 'next-auth/react';
 import { useSyncRecoil } from 'src/core/hooks/useSyncRecoil';
 import { User } from 'src/recoil/auth/type';
 import auth from 'src/recoil/auth';
@@ -33,7 +32,6 @@ const Message = styled.div`
 
 export default function NotFound() {
   const router = useRouter();
-  const session = useSession();
   const { userId } = useSyncRecoil<User>({ atom: auth, defaultValue: authDefaultValue });
   const login = () => router.push(route.Landing);
   const goMyPage = () => router.push({ pathname: route.List, query: { userId } });
@@ -45,7 +43,7 @@ export default function NotFound() {
         <div>퍼즐의 주인이 되어주세요!</div>
       </Message>
       <KakaoAdFit />
-      {session.status === 'authenticated' ? (
+      {userId ? (
         <Button buttonType={ButtonType.Basic} onClick={goMyPage}>
           내 퍼즐판 가기
         </Button>

--- a/src/components/wizard/puzzle/step3/ThirdStep.tsx
+++ b/src/components/wizard/puzzle/step3/ThirdStep.tsx
@@ -34,7 +34,7 @@ function ThirdStep() {
     return `2023년, 6월부터 만 나이가 적용되면서 
 우리에게 ${d_day}일의 시간이 선물처럼 다가왔어요.
 선물로 다가온 소중한 ${d_day}일 동안 ${nickname} 님이 이뤄낼,
-${categoryMap[category]}의 목표를 적고 친구, 지인에게 공유해보세요!
+${categoryMap[category]}의 목표를 한 줄로 적고 친구, 지인에게 공유해보세요!
 `;
   }, [nickname, category, birth]);
 
@@ -56,8 +56,7 @@ ${categoryMap[category]}의 목표를 적고 친구, 지인에게 공유해보�
               inputProps={{ maxLength: 30 }}
               sx={{ height: '170px' }}
               placeholder="목표를 입력해주세요!"
-              multiline={true}
-              maxRows={5}
+              multiline={false}
             />
           )}
         />

--- a/src/module/puzzles/hooks/usePuzzles.ts
+++ b/src/module/puzzles/hooks/usePuzzles.ts
@@ -1,24 +1,9 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
-import { ExceptionCode } from 'src/core/const/enum';
-import route from 'src/core/const/route.path';
 import { ApiError } from 'src/core/type/ApiError';
 import { fetchPuzzles } from '../api';
 import { PUZZLES_KEY } from '../key';
 import { Puzzles } from '../types';
 
 export const usePuzzles = (userId: string, options?: UseQueryOptions<Puzzles, ApiError>) => {
-  const router = useRouter();
-
-  return useQuery<Puzzles, ApiError>([PUZZLES_KEY, userId], () => fetchPuzzles(userId), {
-    ...options,
-    onSuccess: (data) => {
-      if (data?.code === ExceptionCode.invalidUser) {
-        router.push(route.NotFound);
-      }
-      if (options?.onSuccess instanceof Function) {
-        options.onSuccess(data);
-      }
-    },
-  });
+  return useQuery<Puzzles, ApiError>([PUZZLES_KEY, userId], () => fetchPuzzles(userId), options);
 };

--- a/src/pages/how-to-use/index.tsx
+++ b/src/pages/how-to-use/index.tsx
@@ -41,6 +41,21 @@ const CreatePuzzle = styled.button`
   font-size: 14px;
 `;
 
+const ContactUs = styled.div<{ isMobileView: boolean }>`
+  width: ${(props) => (props.isMobileView ? '330px' : '620px')};
+  height: 60px;
+  margin: 10px 0;
+  border-radius: 15px;
+  font-size: 12px;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 5px;
+  border: 1px dashed gray;
+`;
+
 // 이용방법과 광고가 들어갑니다.
 export default function HowToUse() {
   const { isSignUp } = useSyncRecoil<User>({ atom: auth, defaultValue: authDefaultValue });
@@ -58,6 +73,10 @@ export default function HowToUse() {
           width={isMobileView ? '330' : '620'}
           height={isMobileView ? '520' : '720'}
         />
+        <ContactUs isMobileView={isMobileView}>
+          <h5>이용 중 개선사항/문의는 아래 메일에 남겨주세요.</h5>
+          <p>kangactor1994@gmail.com</p>
+        </ContactUs>
         <KakaoAdFit />
       </HowToUseWrap>
     </Layout>


### PR DESCRIPTION
4/30 변경점

1. 퍼즐 생성 시 목표를 한 줄로만 입력받게 수정 (문구도 수정됨)
2. DM 보낼 때 보내는 도중 DM 보내기를 여러번 눌러서 생길 수 있는 버그를 방지하기 위해서 네트워크 요청 중이면 DM 보내기 버튼 비활성화 처리
3. 편지 오픈할 때 key 로직 관련 있었던 버그 픽스
4. 이용방법 페이지에서 아래와 같이 연락처 추가
5. 프론트 넥스트 서버단에서 쿼리 없거나 userId 비어있으면 바로 notFound 로 리다이렉트 시키도록 변경했어유